### PR TITLE
Exclude incubator directory

### DIFF
--- a/scancode/ASF-Release.cfg
+++ b/scancode/ASF-Release.cfg
@@ -46,6 +46,7 @@ ASFLicenseHeaderLua.txt
 
 # List of paths (inclusive of subdirectories) to exclude from code scanning
 [Excludes]
+incubator/
 
 # General tooling & binary file exclusions
 .bin


### PR DESCRIPTION
Adds an exception to the incubator directory to allow people to iterate without breaking the travis build.