### PR TITLE
Improve pre-commit sample for openwhisk

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,12 @@ It is worth adding a Git [pre-commit hook](https://git-scm.com/book/en/v2/Custom
 $ cat /path/to/openwhisk/.git/hooks/pre-commit
 #!/usr/bin/env bash
 
+# -- Code scanning --
+# See https://github.com/apache/openwhisk-utilities
 # determine openwhisk base directory
 root="$(git rev-parse --show-toplevel)"
-python /path/to/openwhisk-utilities/scancode/scanCode.py . --config $root/tools/ --gitignore $root/.gitignore
+scancode_path="/path/to/openwhisk-utilities/scancode"
+python $scancode_path/scanCode.py --config $scancode_path/ASF-Release.cfg --gitignore $root/.gitignore $root
 ```
 
 _Note_: A hook a locally installed, so if you check out the repository again, you will need to reinstall it.


### PR DESCRIPTION
The current code sample does not scan the full openwhisk directory but only starting from the current directory. In addition, no configuration file is specified.

With this change, the pre-commit hook scans the full openwhisk directory and uses the scan configuration that is also used in the openwhisk Travis configuration.

https://github.com/apache/openwhisk/blob/06362ad83608335a01ccbb4ef449ec4c0e70dd99/tools/travis/scan.sh#L35-L37

The openwhisk Travis script does not consider the repo's `.gitignore` file because it always runs on a fresh clone. A pre-commit hook runs on a working clone so that build directories specified in the `.gitignore` file must be excluded.