### PR TITLE
Exclude auto-generated protobuf files

### DIFF
--- a/scancode/ASF-Release.cfg
+++ b/scancode/ASF-Release.cfg
@@ -106,6 +106,9 @@ scancode/lib/pathspec.py
 scancode/lib/pattern.py
 scancode/lib/util.py
 
+# Exclude auto generated protobuf files
+**/build/generated/source/proto/
+
 [Options]
 # Not all code files allow licenses to appear starting at the first character
 # of the file. This option tells the scan to allow licenses to appear starting


### PR DESCRIPTION
## Description
It excludes files auto-generated by the Scala Plugin for the Protocol Buffer Compiler.
I couldn't find a way to add a license header for the auto-generated file.

Those excluded protobuf files will be used for the new scheduler contribution (GRPC).

## Related issue
https://github.com/apache/openwhisk/pull/5070