### PR TITLE
Include php, dotnet, typescript for scancode

### DIFF
--- a/scancode/ASF-Release.cfg
+++ b/scancode/ASF-Release.cfg
@@ -24,6 +24,9 @@ ASFLicenseHeaderLua.txt
 *.html=has_block_license, no_trailing_spaces, eol_at_eof, regex_check
 *.java=no_tabs, has_block_license, no_trailing_spaces, eol_at_eof, regex_check
 *.js=no_tabs, has_block_license, no_trailing_spaces, eol_at_eof, regex_check
+*.ts=no_tabs, has_block_license, no_trailing_spaces, eol_at_eof, regex_check
+*.cs=no_tabs, has_block_license, no_trailing_spaces, eol_at_eof, regex_check
+*.php=no_tabs, has_block_license, no_trailing_spaces, eol_at_eof, regex_check
 *.lua=has_block_license, no_trailing_spaces, eol_at_eof, regex_check
 *.md=no_tabs, has_block_license, no_trailing_spaces, eol_at_eof, regex_check
 *.properties=no_tabs, has_block_license, no_trailing_spaces, eol_at_eof, regex_check
@@ -105,6 +108,9 @@ scancode/lib/gitwildmatch.py
 scancode/lib/pathspec.py
 scancode/lib/pattern.py
 scancode/lib/util.py
+
+# Exclude auto generated protobuf files
+**/build/generated/source/proto2/
 
 [Options]
 # Not all code files allow licenses to appear starting at the first character

--- a/scancode/ASF-Release.cfg
+++ b/scancode/ASF-Release.cfg
@@ -109,9 +109,6 @@ scancode/lib/pathspec.py
 scancode/lib/pattern.py
 scancode/lib/util.py
 
-# Exclude auto generated protobuf files
-**/build/generated/source/proto2/
-
 [Options]
 # Not all code files allow licenses to appear starting at the first character
 # of the file. This option tells the scan to allow licenses to appear starting

--- a/scancode/ASFLicenseHeaderPHP.txt
+++ b/scancode/ASFLicenseHeaderPHP.txt
@@ -1,0 +1,17 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/scancode/travis.cfg
+++ b/scancode/travis.cfg
@@ -24,6 +24,7 @@ ASFMinifiedLicenseHeaderREM.txt
 *.html=has_block_license, no_trailing_spaces, eol_at_eof, regex_check
 *.java=no_tabs, has_block_license, no_trailing_spaces, eol_at_eof, regex_check
 *.js=no_tabs, has_block_license, no_trailing_spaces, eol_at_eof, regex_check
+*.ts=no_tabs, has_block_license, no_trailing_spaces, eol_at_eof, regex_check
 *.lua=has_block_license, no_trailing_spaces, eol_at_eof, regex_check
 *.md=no_tabs, has_block_license, no_trailing_spaces, eol_at_eof, regex_check
 *.properties=no_tabs, has_block_license, no_trailing_spaces, eol_at_eof, regex_check

--- a/scancode/travis.cfg
+++ b/scancode/travis.cfg
@@ -8,6 +8,7 @@ ASFLicenseHeader.txt
 ASFLicenseHeaderBash.txt
 ASFLicenseHeaderHash.txt
 ASFLicenseHeaderLua.txt
+ASFLicenseHeaderPHP.txt
 ASFMinifiedLicenseHashHeader.txt
 ASFMinifiedLicenseHeader.txt
 ASFMinifiedLicenseHeaderREM.txt
@@ -25,6 +26,8 @@ ASFMinifiedLicenseHeaderREM.txt
 *.java=no_tabs, has_block_license, no_trailing_spaces, eol_at_eof, regex_check
 *.js=no_tabs, has_block_license, no_trailing_spaces, eol_at_eof, regex_check
 *.ts=no_tabs, has_block_license, no_trailing_spaces, eol_at_eof, regex_check
+*.cs=no_tabs, has_block_license, no_trailing_spaces, eol_at_eof, regex_check
+*.php=no_tabs, has_block_license, no_trailing_spaces, eol_at_eof, regex_check
 *.lua=has_block_license, no_trailing_spaces, eol_at_eof, regex_check
 *.md=no_tabs, has_block_license, no_trailing_spaces, eol_at_eof, regex_check
 *.properties=no_tabs, has_block_license, no_trailing_spaces, eol_at_eof, regex_check


### PR DESCRIPTION
## Description
I include a typescript, dotnet, PHP for scancode script because the VSCode extension, and dotnet and PHP runtimes are using those languages.

https://github.com/apache/openwhisk-vscode-extension

One concern is that this change will affect all projects under the openwhisk project. 
If you have a project that uses TypeScript, PHP and Dotnet, it also needs to be reviewed with this change.