### PR TITLE
GitHub action to run scanCode.py

### DIFF
--- a/scancode/Dockerfile
+++ b/scancode/Dockerfile
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM python:alpine3.17
+
+COPY *.cfg /scancode/
+COPY ASF*.txt /scancode/
+COPY lib /scancode/lib
+COPY scanCode.py /scancode/scanCode.py
+COPY entrypoint.sh /scancode/entrypoint.sh
+
+ENTRYPOINT ["/scancode/entrypoint.sh"]

--- a/scancode/action.yaml
+++ b/scancode/action.yaml
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: 'scanCode'
+description: 'Run scanCode.py on WORKING_DIR'
+inputs:
+  config:
+    description: 'Configuration file defining the rules to apply'
+    required: false
+    default: 'ASF-Release.cfg'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.config }}

--- a/scancode/entrypoint.sh
+++ b/scancode/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh -l
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+python3 /scancode/scanCode.py . --config /scancode/$1


### PR DESCRIPTION
Define a Dockerfile-based GitHub action to run scanCode.py.  This action can be used as a step in workflows to perform code scanning on the checked out source code.  For example:
```
jobs:
  scancode:
    runs-on: ubuntu-22.04
    steps:
      - name: Checkout
        uses: actions/checkout@v3
      - name: Scan Code
        uses: dgrove-oss/openwhisk-utilities/scancode@action
```

Once this PR is merged, we can refer simply to `apache/openwhisk-utilities/scancode` as the action name in workflow files.